### PR TITLE
Complete migration from betawaffle to cue-sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## What it's for
 
-CUE - Configure, Unify, Execute - is a language designed for designing, 
+CUE - Configure, Unify, Execute - is a language designed for designing,
 generating, and validating data. Read more about it on [the official site, cuelang.org](https://cuelang.org).
 
 ## Why this extension is useful
@@ -17,8 +17,12 @@ Unfortunately, the `.cue` extension which CUE uses is squatted on in the "offici
 So for the moment, manual installation is required. This is quite simple though. Once you have VSCode installed, simply clone this repo into its extension location:
 
 ```shell
-    cd ~/.vscode/extensions
-    git clone git@github.com:betawaffle/vscode-cue.git
+git clone https://github.com/cue-sh/vscode-cue ~/.vscode/extensions/vscode-cue
 ```
 
 Restart VSCode and you should have syntax highlighting for any `.cue` files you load.
+
+## Credits
+
+This project was started by [betawaffle](https://github.com/betawaffle) who graciously permitted that it be moved
+to a more general home in the [cue-sh](https://github.com/cue-sh) organisation.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/betawaffle/vscode-cue
+module github.com/cue-sh/vscode-cue
 
 go 1.12


### PR DESCRIPTION
* Simplify installation instructions
* Change module path (will make gen-syntax command internal in a later
  PR)
* Add credits to betawaffle