### PR TITLE
syntaxes: add fileTypes for TextMate highlighters such as Syntect and Sourcegraph

### DIFF
--- a/internal/cmd/gen-syntax/defs.go
+++ b/internal/cmd/gen-syntax/defs.go
@@ -6,14 +6,16 @@ import (
 )
 
 var root = struct {
-	Schema     string  `json:"$schema"`
-	Name       string  `json:"name"`
-	ScopeName  string  `json:"scopeName"`
-	Patterns   Rules   `json:"patterns"`
-	Repository RuleMap `json:"repository"`
+	Schema     string   `json:"$schema"`
+	Name       string   `json:"name"`
+	FileTypes  []string `json:"fileTypes"`
+	ScopeName  string   `json:"scopeName"`
+	Patterns   Rules    `json:"patterns"`
+	Repository RuleMap  `json:"repository"`
 }{
 	Schema:     "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	Name:       "CUE",
+	FileTypes:  []string{"cue"},
 	ScopeName:  "source.cue",
 	Patterns:   patterns,
 	Repository: repository,

--- a/syntaxes/cue.tmLanguage.json
+++ b/syntaxes/cue.tmLanguage.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "CUE",
+	"fileTypes": ["cue"],
 	"scopeName": "source.cue",
 	"patterns": [
 		{

--- a/syntaxes/cue.tmLanguage.json
+++ b/syntaxes/cue.tmLanguage.json
@@ -1,7 +1,9 @@
 {
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "CUE",
-	"fileTypes": ["cue"],
+	"fileTypes": [
+		"cue"
+	],
 	"scopeName": "source.cue",
 	"patterns": [
 		{


### PR DESCRIPTION
I'm working on adding syntax highlighting for Cue to Sourcegraph - and almost had it working today but found out that we're missing the `fileTypes` declaration here (which is what we use in [syntect_server](github.com/sourcegraph/syntect_server) to detect file types.)

Once this is merged, I should be able to get syntax highlighting of Cue files on Sourcegraph.com working sometime next week (and in our next release.) :) 

Note that this is just following the TextMate grammar / JSON schema format, nothing here is unique to Sourcegraph:

```
            "fileTypes": {
              "description": "this is an array of file type extensions that the grammar should (by default) be used with. This is referenced when TextMate does not know what grammar to use for a file the user opens. If however the user selects a grammar from the language pop-up in the status bar, TextMate will remember that choice.",
              "type": "array",
              "items": { "type": "string" }
            },
```

If there are other common extensions than just `.cue` that should be considered Cue language files, we should include them here as well.